### PR TITLE
TableBlock template customisation (tabindex)

### DIFF
--- a/ietf/templates/includes/tableblock.html
+++ b/ietf/templates/includes/tableblock.html
@@ -1,0 +1,59 @@
+{% load table_block_tags %}
+
+<table tabindex="0">
+    {% if table_caption %}
+       <caption>{{ table_caption }}</caption>
+    {% endif %}
+    {% if table_header %}
+        <thead>
+        <tr>
+            {% for column in table_header %}
+            {% with forloop.counter0 as col_index %}
+                <th scope="col" {% cell_classname 0 col_index %}>
+                    {% if column.strip %}
+                        {% if html_renderer %}
+                            {{ column.strip|safe|linebreaksbr }}
+                        {% else %}
+                            {{ column.strip|linebreaksbr }}
+                        {% endif %}
+                    {% endif %}
+                </th>
+            {% endwith %}
+            {% endfor %}
+        </tr>
+        </thead>
+    {% endif %}
+    <tbody>
+    {% for row in data %}
+    {% with forloop.counter0 as row_index %}
+        <tr>
+            {% for column in row %}
+            {% with forloop.counter0 as col_index %}
+                {% if first_col_is_header and forloop.first %}
+                    <th scope="row" {% cell_classname row_index col_index table_header %}>
+                        {% if column.strip %}
+                            {% if html_renderer %}
+                                {{ column.strip|safe|linebreaksbr }}
+                            {% else %}
+                                {{ column.strip|linebreaksbr }}
+                            {% endif %}
+                        {% endif %}
+                    </th>
+                 {% else %}
+                    <td {% cell_classname row_index col_index table_header %}>
+                        {% if column.strip %}
+                            {% if html_renderer %}
+                                {{ column.strip|safe|linebreaksbr }}
+                            {% else %}
+                                {{ column.strip|linebreaksbr }}
+                            {% endif %}
+                        {% endif %}
+                    </td>
+                 {% endif %}
+            {% endwith %}
+            {% endfor %}
+        </tr>
+    {% endwith %}
+    {% endfor %}
+    </tbody>
+</table>

--- a/ietf/utils/blocks.py
+++ b/ietf/utils/blocks.py
@@ -12,4 +12,4 @@ class StandardBlock(StreamBlock):
     image = ImageChooserBlock(icon="image", template='includes/imageblock.html')
     embed = EmbedBlock(icon="code")
     raw_html = RawHTMLBlock(icon="placeholder")
-    table = TableBlock(table_options={'renderer': 'html'})
+    table = TableBlock(table_options={'renderer': 'html'}, template="includes/tableblock.html")


### PR DESCRIPTION
Changed default template of `TableBlock` stream field component to allow code customisation:
```
<table tabindex="0">
   ...
</table>
```
New stream field component template: `ietf/templates/includes/tableblock.html`