### PR TITLE
Feature/ietf 21 standard index page

### DIFF
--- a/ietf/standard/templates/standard/standard_index_page.html
+++ b/ietf/standard/templates/standard/standard_index_page.html
@@ -1,62 +1,78 @@
 {% extends "base.html" %}
 {% load wagtailcore_tags %}
+{% load has_tabs %}
 
 {% block head_content %}
   {% include 'includes/optional-introduction.html' with value=self %}
   {% include "includes/social_fields.html" %}
 
-  <div class="more-wrapper" style="display: none">
-    {% if self.key_info and self.in_depth %}
-      <div class="read-more">
-        <a class="see">Key info</a>
-        <a class="hide">Close Key info</a>
-      </div>
-      <div class="read-more-two">
-        <a class="see">In depth</a>
-        <a class="hide">Close In depth</a>
-      </div>
-    {% endif %}
+  {% if self.key_info or self.in_depth %}
+    <div class="no-js-hide u-max-text-width">
+      {% has_tabs self.key_info self.in_depth as show_tabs %}
+        {% if show_tabs %}
+          <ul class="nav nav-tabs text-uppercase text-center" id="tabs" role="tablist" aria-owns="key-info-tab in-depth-tab">
+            <li class="nav-item flex-grow-1" role="presentation">
+              <a class="nav-link active" id="key-info-tab" data-toggle="tab" href="#key-info" role="tab"
+                aria-controls="key-info" aria-selected="true">Key Info</a>
+            </li>
+            <li class="nav-item flex-grow-1" role="presentation">
+              <a class="nav-link" id="in-depth-tab" data-toggle="tab" href="#in-depth" role="tab" aria-controls="in-depth"
+                aria-selected="false">In Depth</a>
+            </li>
+          </ul>
+        {% endif %}
 
-    {% if self.key_info %}
-      <div class="read-more-content">
-        {% include_block self.key_info %}
+        <div class="mb-3">
+          <div class="{% if show_tabs %}mb-3 tab-content bg-white border border-top-0{% endif %}">
+            {% if self.key_info %}
+            <div id="key-info" class="{% if show_tabs %} tab-pane fade show active p-3" tabindex="0"
+              role="tabpanel" aria-labelledby="key-info-tab{% endif %}">
+              {{ self.key_info|safe }}
+            </div>
+            {% endif %}
+        
+            {% if self.in_depth %}
+            <div id="in-depth" class="{% if show_tabs %} tab-pane fade p-3" role="tabpanel"
+              aria-labelledby="in-depth-tab{% endif %}">
+              {{ self.in_depth|safe }}
+            </div>
+            {% endif %}
+          </div>
+        </div>
       </div>
     {% endif %}
-
-    {% if self.in_depth %}
-      <div class="read-more-content-two">
-        {% include_block self.in_depth %}
-      </div>
-    {% endif %}
-  </div>
 
 {% endblock head_content %}
 
 {% block content %}
 
-  <ul class="text-listing two-col">
+<div class="container">
+  <ul class="row list-unstyled mt-5">
     {% for child in self.children %}
-        <li>
-        <div class="content-text">
-          <h2 class="xlarge"><a href="{% pageurl child %}">{{ child.title }}</a></h2>
-          <p>{% if child.search_description %}{{ child.search_description }}{% else %}{{ child.introduction }}{% endif %}</p>
-        </div>
-        {% if child.feed_related_links.exists %}
-          <span class="feedback link-toggle">
-            <a class="see">Related</a>
-            <a class="hide">Close</a>
-          </span>
-          <ul>
-            <li class="content">
-              {% for related in child.feed_related_links.all %}
-                <li><a href="{{ related.link }}">{{ related.title }}</a></li>
-              {% endfor %}
-            </li>
-          </ul>
-        {% endif %}
-    </li>
+        <li class="col-12 col-lg-6 mb-4">
+          <div class="content-text">
+            <h2 class="h3"><a href="{% pageurl child %}">{{ child.title }}<span class="icon ion-ios-arrow-forward ml-3"></span></a></h2>
+            <p>{% if child.search_description %}{{ child.search_description }}{% else %}{{ child.introduction }}{% endif %}</p>
+            
+            {% if child.feed_related_links.exists %}
+              <p class="no-js-hide">
+                <a data-toggle="collapse" href="#collapse{{ related.title|slugify }}" role="button" aria-expanded="false" aria-controls="collapseExample">
+                  Related<span class="icon ion-ios-arrow-down ml-2"></span>
+                </a>
+              </p>
+              <div class="collapse mt-n2 no-js-hide" id="collapse{{ related.title|slugify }}">
+                  <ul>
+                    {% for related in child.feed_related_links.all %}
+                      <li><a href="{{ related.link }}">{{ related.title }}</a></li>
+                    {% endfor %}
+                  </ul>
+              </div>
+            {% endif %}
+          </div>
+      </li>
     {% endfor %}
 
   </ul>
+</div>
 
 {% endblock %}

--- a/ietf/standard/templates/standard/standard_index_page.html
+++ b/ietf/standard/templates/standard/standard_index_page.html
@@ -50,25 +50,23 @@
   <ul class="row list-unstyled mt-5">
     {% for child in self.children %}
         <li class="col-12 col-lg-6 mb-4">
-          <div class="content-text">
-            <h2 class="h3"><a href="{% pageurl child %}">{{ child.title }}<span class="icon ion-ios-arrow-forward ml-3"></span></a></h2>
-            <p>{% if child.search_description %}{{ child.search_description }}{% else %}{{ child.introduction }}{% endif %}</p>
-            
-            {% if child.feed_related_links.exists %}
-              <p class="no-js-hide">
-                <a data-toggle="collapse" href="#collapse{{ related.title|slugify }}" role="button" aria-expanded="false" aria-controls="collapseExample">
-                  Related<span class="icon ion-ios-arrow-down ml-2"></span>
-                </a>
-              </p>
-              <div class="collapse mt-n2 no-js-hide" id="collapse{{ related.title|slugify }}">
-                  <ul>
-                    {% for related in child.feed_related_links.all %}
-                      <li><a href="{{ related.link }}">{{ related.title }}</a></li>
-                    {% endfor %}
-                  </ul>
-              </div>
-            {% endif %}
-          </div>
+          <h2 class="h3"><a href="{% pageurl child %}">{{ child.title }}<span class="icon ion-ios-arrow-forward ml-3"></span></a></h2>
+          <p>{% if child.search_description %}{{ child.search_description }}{% else %}{{ child.introduction }}{% endif %}</p>
+          
+          {% if child.feed_related_links.exists %}
+            <p class="no-js-hide">
+              <a data-toggle="collapse" href="#collapse{{ related.title|slugify }}" role="button" aria-expanded="false" aria-controls="collapseExample">
+                Related<span class="icon ion-ios-arrow-down ml-2"></span>
+              </a>
+            </p>
+            <div class="collapse mt-n2 no-js-hide" id="collapse{{ related.title|slugify }}">
+                <ul>
+                  {% for related in child.feed_related_links.all %}
+                    <li><a href="{{ related.link }}">{{ related.title }}</a></li>
+                  {% endfor %}
+                </ul>
+            </div>
+          {% endif %}
       </li>
     {% endfor %}
 

--- a/ietf/static_src/css/main.scss
+++ b/ietf/static_src/css/main.scss
@@ -8,3 +8,4 @@
 @import './utilities.scss'; // Utility classes that don't exist in Bootstrap yet
 @import './streamfield.scss'; // Styles for streamfield blocks
 @import './datepicker.scss'; // Styles for jquery-ui datepicker
+@import './no-js.scss'; // Styles for when javascript is disabled

--- a/ietf/static_src/css/no-js.scss
+++ b/ietf/static_src/css/no-js.scss
@@ -1,0 +1,3 @@
+.no-js .no-js-hide {
+    display: none;
+}

--- a/ietf/static_src/css/utilities.scss
+++ b/ietf/static_src/css/utilities.scss
@@ -10,3 +10,7 @@
 .u-max-text-width {
     max-width: 50rem;
 }
+
+.no-js .no-js-hide {
+    display: none;
+}

--- a/ietf/static_src/css/utilities.scss
+++ b/ietf/static_src/css/utilities.scss
@@ -10,7 +10,3 @@
 .u-max-text-width {
     max-width: 50rem;
 }
-
-.no-js .no-js-hide {
-    display: none;
-}

--- a/ietf/static_src/js/init.js
+++ b/ietf/static_src/js/init.js
@@ -7,3 +7,5 @@ import 'bootstrap';
 window.$ = $;
 window.jQuery = $;
 window.Popper = Popper;
+
+document.documentElement.classList.remove('no-js');

--- a/ietf/templates_src/base.html
+++ b/ietf/templates_src/base.html
@@ -59,7 +59,7 @@
 
         {% block main_content %}
         <main role="main">
-            <div class="bg-white border-bottom">
+            <div class="bg-white border-bottom pb-3">
                 <div class="container">
                     {% include 'includes/breadcrumbs.html' %}
                     {% block head_content %}{% endblock head_content %}


### PR DESCRIPTION
How it looks when there is content for both "key info" and "in depth":
![Screen Shot 2020-10-15 at 3 37 54 PM](https://user-images.githubusercontent.com/1134713/96072472-dd2c0b80-0f00-11eb-9e98-b9ec6031f327.png)

The tab bar won't show if only one of these sections is populated, because the single tab would be pointless. But the content will show.

How it looks when a child page has `feed_related_links` (I couldn't find an example on the legacy site!):
[related feed links.mov.zip](https://github.com/ietf-tools/wagtail_website/files/5382212/related.feed.links.mov.zip)

Neither the tab content or the feed links dropdown content will show if JS is disabled - this is how the legacy site works also.