### PR TITLE
Fix table scrolling

### DIFF
--- a/ietf/static_src/css/streamfield.scss
+++ b/ietf/static_src/css/streamfield.scss
@@ -18,30 +18,36 @@
 $table-padding: 20px;
 $border-colour: #e1e4e5;
 
+.block-table__container {
+    overflow: scroll;
+    @include media-breakpoint-up(sm) {
+        overflow: auto;
+    }
+}
+
 .block-table {
     margin: 30px 0;
-    overflow: scroll;
-    border: 1px solid $border-colour;
+    // border: 1px solid $border-colour;
 
     @include media-breakpoint-up(sm) {
         margin: 50px 0;
         border: 0;
-        overflow: auto;
         width: calc(100% - 50px);
     }
-
+}
+.block-table,
+.block-table__container {
     > table {
         width: 100%;
         display: table;
-        overflow: scroll;
 
         @include media-breakpoint-up(sm) {
             width: calc(100% - 50px);
-            overflow: auto;
         }
 
         > tbody {
             width: 100%;
+            background-color: $white;
         }
 
         > caption {

--- a/ietf/templates/includes/tableblock.html
+++ b/ietf/templates/includes/tableblock.html
@@ -1,36 +1,16 @@
 {% load table_block_tags %}
 
-<table tabindex="0">
-    {% if table_caption %}
-       <caption>{{ table_caption }}</caption>
-    {% endif %}
-    {% if table_header %}
-        <thead>
-        <tr>
-            {% for column in table_header %}
-            {% with forloop.counter0 as col_index %}
-                <th scope="col" {% cell_classname 0 col_index %}>
-                    {% if column.strip %}
-                        {% if html_renderer %}
-                            {{ column.strip|safe|linebreaksbr }}
-                        {% else %}
-                            {{ column.strip|linebreaksbr }}
-                        {% endif %}
-                    {% endif %}
-                </th>
-            {% endwith %}
-            {% endfor %}
-        </tr>
-        </thead>
-    {% endif %}
-    <tbody>
-    {% for row in data %}
-    {% with forloop.counter0 as row_index %}
-        <tr>
-            {% for column in row %}
-            {% with forloop.counter0 as col_index %}
-                {% if first_col_is_header and forloop.first %}
-                    <th scope="row" {% cell_classname row_index col_index table_header %}>
+<div class="block-table__container" >
+    <table tabindex="0">
+        {% if table_caption %}
+            <caption>{{ table_caption }}</caption>
+        {% endif %}
+        {% if table_header %}
+            <thead>
+            <tr>
+                {% for column in table_header %}
+                {% with forloop.counter0 as col_index %}
+                    <th scope="col" {% cell_classname 0 col_index %}>
                         {% if column.strip %}
                             {% if html_renderer %}
                                 {{ column.strip|safe|linebreaksbr }}
@@ -39,21 +19,43 @@
                             {% endif %}
                         {% endif %}
                     </th>
-                 {% else %}
-                    <td {% cell_classname row_index col_index table_header %}>
-                        {% if column.strip %}
-                            {% if html_renderer %}
-                                {{ column.strip|safe|linebreaksbr }}
-                            {% else %}
-                                {{ column.strip|linebreaksbr }}
+                {% endwith %}
+                {% endfor %}
+            </tr>
+            </thead>
+        {% endif %}
+        <tbody>
+        {% for row in data %}
+        {% with forloop.counter0 as row_index %}
+            <tr>
+                {% for column in row %}
+                {% with forloop.counter0 as col_index %}
+                    {% if first_col_is_header and forloop.first %}
+                        <th scope="row" {% cell_classname row_index col_index table_header %}>
+                            {% if column.strip %}
+                                {% if html_renderer %}
+                                    {{ column.strip|safe|linebreaksbr }}
+                                {% else %}
+                                    {{ column.strip|linebreaksbr }}
+                                {% endif %}
                             {% endif %}
-                        {% endif %}
-                    </td>
-                 {% endif %}
-            {% endwith %}
-            {% endfor %}
-        </tr>
-    {% endwith %}
-    {% endfor %}
-    </tbody>
-</table>
+                        </th>
+                    {% else %}
+                        <td {% cell_classname row_index col_index table_header %}>
+                            {% if column.strip %}
+                                {% if html_renderer %}
+                                    {{ column.strip|safe|linebreaksbr }}
+                                {% else %}
+                                    {{ column.strip|linebreaksbr }}
+                                {% endif %}
+                            {% endif %}
+                        </td>
+                    {% endif %}
+                {% endwith %}
+                {% endfor %}
+            </tr>
+        {% endwith %}
+        {% endfor %}
+        </tbody>
+    </table>
+</div>


### PR DESCRIPTION
Context:

Ideally we'd like the tables to be scrollable horizontally when the screen is not wide enough to display everything. For that to be accessible we need a `tabindex="0"` on the element that's scrollable. The problem is, these tables are a block in a streamfield and until now did not have a template or a way to set the `tabindex` on the `div` containing the table. Daniel made it so tables now use a template that we can modify.

The other issue is, that only applies to newly created tables. We'd have to re-publish (possibly using a script) all pages that include a table to force Wagtail to reprocess them so they render with the template. That brings the issue of potentially losing bibliography which is a legacy feature that only exists on old pages, and republishing a page just loses the information about them. Even restoring the page to an older draft does not bring them back. (see [this comment for more details](https://springload-nz.atlassian.net/browse/IETF-22?focusedCommentId=18250))

I'm not sure what's best to do about them.

This PR assumes that both old and new tables will be coexisting. The new tables will have scrolling enabled and be focusable thanks to the template, while the old ones will just bleed over the edge and force the whole page to scroll horizontally, which is not great but still usable for keyboard users.