### PR TITLE
Reimplement Form page

### DIFF
--- a/ietf/forms/templates/forms/form_page.html
+++ b/ietf/forms/templates/forms/form_page.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <div class="bg-white">
-    <div class="container pb-3">
+    <div class="container pb-3 pt-4">
         <div class="u-max-text-width">
             <h1 class="h2">{{ self.title }}</h1>
             {{ self.intro|richtext }}

--- a/ietf/forms/templates/forms/form_page.html
+++ b/ietf/forms/templates/forms/form_page.html
@@ -38,7 +38,7 @@
                                         {% endif %}
                                     </label>
                                     {% if field.help_text %}
-                                        <small id="{{ field.id_for_label }}_help" class="form-text text-muted">
+                                        <small id="{{ field.id_for_label }}_help" class="text-muted">
                                             {{ field.help_text }}
                                         </small>
                                     {% endif %}
@@ -52,7 +52,7 @@
                                     {% endif %}
                                 </label>
                                 {% if field.help_text %}
-                                    <small id="{{ field.id_for_label }}_help" class="form-text text-muted">
+                                    <small id="{{ field.id_for_label }}_help" class="text-muted">
                                         {{ field.help_text }}
                                     </small>
                                 {% endif %}
@@ -73,7 +73,7 @@
                                     {{ field|add_attr:"class:form-control border-primary" }}
                                 {% endif %}
                                 {% if field.help_text %}
-                                    <small id="{{ field.id_for_label }}_help" class="form-text text-muted">
+                                    <small id="{{ field.id_for_label }}_help" class="text-muted">
                                         {{ field.help_text }}
                                     </small>
                                 {% endif %}

--- a/ietf/forms/templates/forms/form_page.html
+++ b/ietf/forms/templates/forms/form_page.html
@@ -2,40 +2,87 @@
 {% load wagtailcore_tags form_tags %}
 
 {% block content %}
-    <div class="body container">
-        <h1>{{ self.title }}</h1>
-        {{ self.intro|richtext }}
-        <form action="{% pageurl self %}" method="POST" class="standard-form">
-            <div>
+<div class="bg-white">
+    <div class="container pb-3">
+        <div class="u-max-text-width">
+            <h1 class="h2">{{ self.title }}</h1>
+            {{ self.intro|richtext }}
+        </div>
+        <form action="{% pageurl self %}" method="POST" class="row">
+            <div class="col-12 col-lg-8 col-xl-6">
                 {% csrf_token %}
 
                 {% if form.errors %}
-                    <p class="error">There were some errors with your form. Please amend the fields highlighted below.</p>
+                    <p class="text-danger">There were some errors with your form. Please amend the fields highlighted below.</p>
                 {% endif %}
 
-                <ul class="fields">
                     {% for field in form %}
-                        <li class="{{ field|fieldtype }} {{ field|widgettype }} {% if field.field.required %}required{% endif %} {% if field.errors %}errors{% endif %}">
+                        <div class="form-group">
                             {% if field.errors %}
-                                {{ field.errors }}
+                                <p class="text-danger">{{ field.errors }}</p>
                             {% endif %}
 
                             {% if field|widgettype == 'checkbox_input' %}
-                                <label for="{{ field.id_for_label }}"> {{ field }} {{ field.label }} {% if field.field.required %}<span class="required">*</span>{% endif %}</label>
-                                <div class="form-help">{% if field.help_text %}{{ field.help_text }}{% endif %}</div>
+                                <div class="form-check">
+                                    {% if field.help_text %}
+                                        {% with "class:form-check-input,aria-labelled-by:"|add:field.id_for_label|add:"_help" as attr %}
+                                            {{ field|add_attr:attr }}
+                                        {% endwith %}
+                                    {% else %}
+                                        {{ field|add_attr:'class:form-check-input' }}
+                                    {% endif %}
+                                    <label class="form-check-label" for="{{ field.id_for_label }}">
+                                        {{ field.label }}
+                                        {% if field.field.required %}
+                                            <span> *</span>
+                                        {% endif %}
+                                    </label>
+                                    {% if field.help_text %}
+                                        <small id="{{ field.id_for_label }}_help" class="form-text text-muted">
+                                            {{ field.help_text }}
+                                        </small>
+                                    {% endif %}
+                                </div>
+
+                            {% elif field|widgettype == 'checkbox_select_multiple' or field|widgettype == 'radio_select' %}
+                                <label for="{{ field.id_for_label }}">
+                                    {{ field.label }}
+                                    {% if field.field.required %}
+                                        <span> *</span>
+                                    {% endif %}
+                                </label>
+                                {% if field.help_text %}
+                                    <small id="{{ field.id_for_label }}_help" class="form-text text-muted">
+                                        {{ field.help_text }}
+                                    </small>
+                                {% endif %}
+                                {{ field|add_attr:"list-unstyled" }}
 
                             {% else %}
-                                <label for="{{ field.id_for_label }}">{{ field.label }} {% if field.field.required %}<span class="required">*</span>{% endif %}</label>
-                                <div class="form-help">{% if field.help_text %}{{ field.help_text }}{% endif %}</div>
-                                {{ field }}
+                                <label for="{{ field.id_for_label }}">
+                                    {{ field.label }} {% if field.field.required %}
+                                    <span class="required">*</span>
+                                    {% endif %}
+                                </label>
+
+                                {% if field.help_text %}
+                                    {% with "class:form-control border-primary,aria-labelled-by:"|add:field.id_for_label|add:"_help" as attr %}
+                                        {{ field|add_attr:attr }}
+                                    {% endwith %}
+                                {% else %}
+                                    {{ field|add_attr:"class:form-control border-primary" }}
+                                {% endif %}
+                                {% if field.help_text %}
+                                    <small id="{{ field.id_for_label }}_help" class="form-text text-muted">
+                                        {{ field.help_text }}
+                                    </small>
+                                {% endif %}
                             {% endif %}
-                        </li>
+                        </div>
                     {% endfor %}
-                    <li class="submit">
-                        <input type="submit" class="button button-inverse" value="{% if self.action_text %}{{ self.action_text|safe }}{% else %}Submit{%endif%}" />
-                    </li>
-                </ul>
+                    <input type="submit" class="btn btn-primary" value="{% if self.action_text %}{{ self.action_text|safe }}{% else %}Submit{%endif%}" />
             </div>
         </form>
     </div>
+</div>
 {% endblock %}

--- a/ietf/forms/templates/forms/form_page_landing.html
+++ b/ietf/forms/templates/forms/form_page_landing.html
@@ -2,5 +2,5 @@
 {% load wagtailcore_tags %}
 
 {% block content %}
-    <div>{{ self.thank_you_text|richtext }}</div>
+    <div class="container">{{ self.thank_you_text|richtext }}</div>
 {% endblock %}

--- a/ietf/forms/templatetags/form_tags.py
+++ b/ietf/forms/templatetags/form_tags.py
@@ -13,3 +13,17 @@ def fieldtype(bound_field):
 @register.filter
 def widgettype(bound_field):
     return camelcase_to_underscore(bound_field.field.widget.__class__.__name__)
+
+@register.filter(name='add_attr')
+def add_attr(bound_field, value):
+    attrs = {}
+    definition = value.split(',')
+
+    for d in definition:
+        if ':' not in d:
+            attrs['class'] = d
+        else:
+            key, val = d.split(':')
+            attrs[key] = val
+
+    return bound_field.as_widget(attrs=attrs)


### PR DESCRIPTION
https://springload-nz.atlassian.net/browse/IETF-27?atlOrigin=eyJpIjoiZGFiZGEyMDgwYWNjNGRjZTg2YjZlNTIwODM3MWM2MDQiLCJwIjoiaiJ9

From this:
![Screen Shot 2020-10-16 at 18 16 35](https://user-images.githubusercontent.com/6631995/96217788-d3c5a080-0fdf-11eb-860e-4b8e11fe4830.png)

To this:
![Screen Shot 2020-10-16 at 18 16 11](https://user-images.githubusercontent.com/6631995/96217796-d88a5480-0fdf-11eb-9a95-7960c83ef2a3.png)

I had to mess with template tags to be able to add attributes to input fields (classes and aria for the helper texts). It's not perfect, especially for checkbox groups and radio groups which I don't know how to iterate on if at all possible.