### PR TITLE
Add bootstrap table scrolling to newly created tables

### DIFF
--- a/ietf/static_src/css/streamfield.scss
+++ b/ietf/static_src/css/streamfield.scss
@@ -34,13 +34,6 @@
 $table-padding: 20px;
 $border-colour: #e1e4e5;
 
-.block-table__container {
-    overflow: scroll;
-    @include media-breakpoint-up(sm) {
-        overflow: auto;
-    }
-}
-
 .block-table {
     margin: 30px 0;
     // border: 1px solid $border-colour;

--- a/ietf/templates/includes/tableblock.html
+++ b/ietf/templates/includes/tableblock.html
@@ -1,6 +1,6 @@
 {% load table_block_tags %}
 
-<div class="block-table__container" >
+<div class="table-responsive">
     <table tabindex="0">
         {% if table_caption %}
             <caption>{{ table_caption }}</caption>


### PR DESCRIPTION
Fix for https://springload-nz.atlassian.net/browse/IETF-129

Using https://getbootstrap.com/docs/5.0/content/tables/#always-responsive

Note, any existing tables won't use this custom table template, this only affects newly created tables (created since this custom table template was added).