### PR TITLE
Update the test for the blogpage

### DIFF
--- a/ietf/blog/tests.py
+++ b/ietf/blog/tests.py
@@ -1,4 +1,5 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
+from django.utils import timezone
 
 from django.test import TestCase
 from wagtail.models import Page, Site
@@ -37,13 +38,13 @@ class BlogTests(TestCase):
         )
         home.add_child(instance=self.blog_index)
 
-        now = datetime.utcnow()
+        now = timezone.now()
 
         self.otherblog = BlogPage(
             slug="otherpost",
             title="other title",
             introduction="other introduction",
-            body="other body",
+            body='[{"id": "1", "type": "rich_text", "value": "<p>other body</p>"}]',
             date_published=(now - timedelta(minutes=10)),
         )
         self.blog_index.add_child(instance=self.otherblog)
@@ -53,7 +54,7 @@ class BlogTests(TestCase):
             slug="prevpost",
             title="prev title",
             introduction="prev introduction",
-            body="prev body",
+            body='[{"id": "2", "type": "rich_text", "value": "<p>prev body</p>"}]',
             date_published=(now - timedelta(minutes=5)),
         )
         self.blog_index.add_child(instance=self.prevblog)
@@ -63,7 +64,7 @@ class BlogTests(TestCase):
             slug="blogpost",
             title="blog title",
             introduction="blog introduction",
-            body="blog body",
+            body='[{"id": "3", "type": "rich_text", "value": "<p>blog body</p>"}]',
             first_published_at=(now + timedelta(minutes=1)),
         )
         self.blog_index.add_child(instance=self.blog)
@@ -73,7 +74,7 @@ class BlogTests(TestCase):
             slug="nextpost",
             title="next title",
             introduction="next introduction",
-            body="next body",
+            body='[{"id": "4", "type": "rich_text", "value": "<p>next body</p>"}]',
             first_published_at=(now + timedelta(minutes=5)),
         )
         self.blog_index.add_child(instance=self.nextblog)

--- a/ietf/home/tests.py
+++ b/ietf/home/tests.py
@@ -43,7 +43,7 @@ class HomeTests(TestCase):
             slug="blogpost",
             title="blog title",
             introduction="blog introduction",
-            body="blog body",
+            body='[{"id": "1", "type": "rich_text", "value": "<p>blog body</p>"}]',
         )
         blogindex.add_child(instance=blog)
 


### PR DESCRIPTION
The 3.0 Wagtail adds a new parameter for the Streamfield `use_json_field=True` and all the data will be saved in JSON format. The test still uses a simple string in the body field which will break the test. This PR is to update the right format in the test.

The change of using `timezone` is to resolve the following warning in the test.
`/usr/local/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1416: RuntimeWarning: DateTimeField BlogPage.date_published received a naive datetime (2022-09-09 01:32:11.499211) while time zone support is active.
  warnings.warn("DateTimeField %s received a naive datetime (%s)"`