### PR TITLE
Feature: use static url in footer image

### DIFF
--- a/ietf/static_src/css/iab.scss
+++ b/ietf/static_src/css/iab.scss
@@ -174,6 +174,8 @@
 
 .iab-footer-image {
     height: 48px;
+    //NB footer has an inline background image, the color is a fallback
+    background-color: white;
 }
 
 .iab_body {

--- a/ietf/templates/includes/footer-iab.html
+++ b/ietf/templates/includes/footer-iab.html
@@ -1,7 +1,7 @@
 {% load static wagtailcore_tags %}
 
 <div
-    style="background-image: url('static/img/background-dark.jpg');"
+style="background-image: url({% static 'img/background-dark.jpg' %});"
     class="iab-footer-image"
 ></div>
 <footer class="iab-bg-navy text-light py-3">


### PR DESCRIPTION
[IAB-36](https://springload-nz.atlassian.net/browse/IAB-36) - use static urls in the footer so it appears properly at all times. Add a white background so that if it ever fails again, the gap matches the rest of the page. 

Note that this is us using the new `integration` branch. This branch is forked off the ietf fork's `deploy/preview`, with a view to making future PRs into the ietf fork from this branch. 

[IAB-36]: https://springload-nz.atlassian.net/browse/IAB-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ