### PR TITLE
remove row styling

### DIFF
--- a/ietf/announcements/templates/announcements/iab_announcement_index_page.html
+++ b/ietf/announcements/templates/announcements/iab_announcement_index_page.html
@@ -13,7 +13,7 @@
     {{ page.body|safe }}
   </div>
   <div class="container">
-    <ul class="row list-unstyled pt-5 pb-4 mb-0">
+    <ul class="list-unstyled pt-5 pb-4 mb-0">
       {% for child in self.children %}
           <li class="col-12 col-lg-6 mb-4">
             <h2 class="h3"><a href="{% pageurl child %}">{{ child.title }}<span class="icon ion-ios-arrow-forward ms-3"></span></a></h2>


### PR DESCRIPTION
[IAB-37](https://springload-nz.atlassian.net/browse/IAB-37)

Client wanted the announcements to appear in a column, so I'm pulling out the flex classes.

Before (gridlines left in because it was flex before):
![Screenshot 2023-05-17 at 1 58 32 PM](https://github.com/ietf-tools/wagtail_website/assets/37293617/8dd84020-32e1-47a6-bd28-ca44b9005fc1)

After:
![Screenshot 2023-05-17 at 1 58 38 PM](https://github.com/ietf-tools/wagtail_website/assets/37293617/368f59a6-6587-4a20-9e89-d0203b6e8004)




[IAB-37]: https://springload-nz.atlassian.net/browse/IAB-37?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ